### PR TITLE
US100403 - Remove race condition between href and ready setting image

### DIFF
--- a/components/d2l-profile-image-base.html
+++ b/components/d2l-profile-image-base.html
@@ -88,7 +88,8 @@ D2L Profile Image
 					value: ''
 				},
 				_imageUrl: {
-					type: String
+					type: String,
+					value: ''
 				},
 				_displayType: {
 					type: String,
@@ -142,8 +143,10 @@ D2L Profile Image
 				this._handleColourId();
 			},
 			ready: function() {
-					this._domReady = true;
+				this._domReady = true;
+				if(!this._imageUrl && this.href) {
 					this._resetImageState();
+				}
 			},
 			_handleColourId: function() {
 				var backgroundColour = this._getInitialedBackgroundColour(this.colourId);

--- a/test/d2l-profile-image-base.html
+++ b/test/d2l-profile-image-base.html
@@ -236,6 +236,27 @@
 					});
 				});
 
+				[
+					{ href: '', imageUrl: '', resetImageState: false },
+					{ href: '', imageUrl: 'valid', resetImageState: false },
+					{ href: 'valid', imageUrl: '', resetImageState: true },
+					{ href: 'valid', imageUrl: 'valid', resetImageState: false },
+				].forEach(function(t) {
+					test('when image is ready, resetImageState only called when imageUrl is not set and href is set', function() {
+						defaultElement.href = t.href;
+						defaultElement._imageUrl = t.imageUrl;
+
+						var resetImageStateSpy = sandbox.spy(defaultElement, '_resetImageState');
+						defaultElement.ready();
+
+						if (t.resetImageState) {
+							assert.isOk(resetImageStateSpy.calledOnce);
+						}
+						else {
+							assert.isOk(resetImageStateSpy.notCalled);
+						}
+					});
+				});
 			});
 		</script>
 	</body>


### PR DESCRIPTION
There was a race condition when using `d2l-profile-image` where sometimes `_domReady ` would fire after `_resetImageState` was already triggered when the `href` was updated to a valid url. Ensure to check `_imageUrl` and `href` to determine if `_resetImageState` should be called when the component is marked as ready


* Planning to release a version after this to BSI