### PR TITLE
US99323 - Fallback to original href if cannot fetch image with javascript

### DIFF
--- a/components/d2l-profile-image-base.html
+++ b/components/d2l-profile-image-base.html
@@ -191,6 +191,8 @@ D2L Profile Image
 			},
 			_resetImageState: function() {
 				this.set('_imageLoading', true);
+				this.set('_failedToLoadImage', false);
+
 				if(!this._domReady) {
 					return Promise.resolve();
 				}
@@ -206,10 +208,9 @@ D2L Profile Image
 					})
 					.then(function(blob){
 						this.set('_imageUrl', URL.createObjectURL(blob));
-						this.set('_failedToLoadImage', false);
 					}.bind(this))
 					.catch(function(){
-						this.set('_failedToLoadImage', true);
+						this.set('_imageUrl', this.href);
 					}.bind(this))
 					.then(function() {
 						this.set('_imageLoading', false);

--- a/components/d2l-profile-image.html
+++ b/components/d2l-profile-image.html
@@ -106,7 +106,7 @@ D2L Profile Image Hypermedia
 								var profileImage = userProfile.getSubEntityByRel('https://api.brightspace.com/rels/profile-image');
 								if (profileImage && !profileImage.hasClass('default-image')) {
 
-									var imageEntity = profileImage.getLinkByRel('https://api.brightspace.com/rels/thumbnail#regular');
+									var imageEntity = profileImage.getLinkByRel('alternate');
 									this.set('_imageUrl', imageEntity.href);
 								}
 							}

--- a/test/d2l-profile-image-base.html
+++ b/test/d2l-profile-image-base.html
@@ -171,7 +171,7 @@
 				test('_resetImageState removes dedupe middleware before fetch', function() {
 					defaultElement._domReady = true;
 
-					var dedupeStub = sinon.stub();
+					var dedupeStub = sandbox.stub();
 					dedupeStub.withArgs(sinon.match('dedupe'))
 						.returns({ fetch: function() { return Promise.resolve(); } });
 
@@ -189,6 +189,8 @@
 				});
 
 				test('_resetImageState will fetch image with correct headers', function() {
+					var expectedImageUrl = 'expectedImageUrl';
+
 					var expectedToken = 'expectedToken';
 					defaultElement.token = expectedToken;
 					defaultElement._domReady = true;
@@ -196,18 +198,33 @@
 					var headers = new Headers();
 					headers.append('Authorization', 'Bearer ' + expectedToken);
 
-					var fetchStub = sinon.stub().returns(Promise.resolve());
-					var dedupeStub = sinon.stub();
+					var blobStub = sandbox.stub();
+					URL.createObjectURL = blobStub;
+					URL.createObjectURL
+						.withArgs(sinon.match('blob'))
+						.returns(expectedImageUrl);
+
+					var fetchStub = sandbox.stub()
+						.returns(Promise.resolve(
+							{
+								'blob': function() {
+									return Promise.resolve('blob');
+								}
+							}
+						));
+					var dedupeStub = sandbox.stub();
 					dedupeStub.withArgs(sinon.match('dedupe'))
 						.returns({ fetch: fetchStub });
 
-					window.d2lfetch.removeTemp = sandbox.stub();
-					window.d2lfetch.removeTemp
+					var simpleCacheStub = sandbox.stub();
+					simpleCacheStub
 						.withArgs(sinon.match('simpleCache'))
 						.returns({removeTemp: dedupeStub});
+					window.d2lfetch.removeTemp = simpleCacheStub;
 
 					return defaultElement._resetImageState()
 						.then(function() {
+							assert.equal(defaultElement._imageUrl, expectedImageUrl);
 							assert.isOk(fetchStub.calledWith(defaultElement.href, sinon.match(function(v) {
 								var correctMethod = v.method === 'GET';
 								var correctHeaderToken = v.headers.get('Authorization') === 'Bearer ' + expectedToken;
@@ -256,6 +273,33 @@
 							assert.isOk(resetImageStateSpy.notCalled);
 						}
 					});
+				});
+
+				// BSI CDN uses opaque resposnes, cannot fetch images via javascript
+				// When failing to fetchn images with javascript allow the image tag to specify the given image directly
+				test('When failing to retrieve image via javascript, fallback and set the _imageUrl to given href', function() {
+					var expectedHref = 'expectedHref';
+
+					var fetchStub = sandbox.stub()
+						.returns(Promise.reject());
+
+					var dedupeStub = sandbox.stub();
+					dedupeStub.withArgs(sinon.match('dedupe'))
+						.returns({ fetch: fetchStub });
+
+					var simpleCacheStub = sandbox.stub();
+					simpleCacheStub
+						.withArgs(sinon.match('simpleCache'))
+						.returns({removeTemp: dedupeStub});
+					window.d2lfetch.removeTemp = simpleCacheStub;
+
+					defaultElement.href = expectedHref;
+					defaultElement._domReady = true;
+
+					return defaultElement._resetImageState()
+						.then(function() {
+							assert.equal(defaultElement._imageUrl, expectedHref);
+						});
 				});
 			});
 		</script>

--- a/test/d2l-profile-image.html
+++ b/test/d2l-profile-image.html
@@ -166,7 +166,7 @@
 										'class': imageClass,
 										'links': [
 											{
-												'rel': ['https://api.brightspace.com/rels/thumbnail#regular'],
+												'rel': ['alternate'],
 												'href': expectedImage
 											}
 										]

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -21,7 +21,7 @@
         {
           "browserName": "safari",
           "platform": "OS X 10.13",
-          "version": ""
+          "version": "11.1"
         },
         {
           "browserName": "microsoftedge",


### PR DESCRIPTION
* Ex: Our CDN does not set CORS headers so the response is opaque. This means we cannot fetch the image via javascript
* So if we cannot fetch the image with JS, let the image tag try and get the resource itself
* https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
* https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Cross-origin_network_access
* Use original image to maintain image quality see pictures below