### PR TITLE
No Authorization header when token is not set

### DIFF
--- a/components/d2l-profile-image-base.js
+++ b/components/d2l-profile-image-base.js
@@ -203,7 +203,9 @@ Polymer({
 		return tokenPromise
 			.then(function(tokenString) {
 				var headers = new Headers();
-				headers.append('Authorization', 'Bearer ' + tokenString);
+				if (tokenString) {
+					headers.append('Authorization', 'Bearer ' + tokenString);
+				}
 				return headers;
 			})
 			.then((function(hdr) {


### PR DESCRIPTION
There are cases in some app that it doesn't pass the token around but relying on the d2lfetch to handle the authorization token. 

