### PR TITLE
Re-enable WCT IE11 and Edge Tests

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -22,6 +22,16 @@
           "browserName": "safari",
           "platform": "OS X 10.13",
           "version": "11.1"
+        },
+        {
+          "browserName": "microsoftedge",
+          "platform": "Windows 10",
+          "version": ""
+        },
+        {
+          "browserName": "internet explorer",
+          "platform": "Windows 10",
+          "version": "11"
         }
       ]
     }


### PR DESCRIPTION
# Changes
-  Re-enable WCT IE11 and Edge Tests tests that were temporarily disabled due to an issue with WCT causing flake.
- [ ] Wait until this fix has been released in 3.1.5:
    - https://github.com/Polymer/tools/pull/727#issuecomment-522711237
    - https://github.com/Polymer/tools/blob/master/packages/build/CHANGELOG.md#change-log