### PR TITLE
use NPM reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
-    "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",
+    "d2l-hypermedia-constants": "^6",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1"
   }


### PR DESCRIPTION
**DO NOT MERGE YET**

I'm queuing up this change across 9 different repos that get pulled into BSI, switching them all to use the NPM reference for `d2l-hypermedia-constants`. Once they're all approved, I'm merge, release & update them all at once.